### PR TITLE
Initial Semantic-Release stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+---
+name: Release
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branch:
+      - "master"
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - denverton
+          - geminilake
+    runs-on: ubuntu-22.04
+    env:
+      SUFFIX: build-${{ matrix.arch }}
+    steps:
+      - name: Clone Repo
+        uses: actions/checkout@v4
+      - name: Build
+        run: date > ${{ env.SUFFIX }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SUFFIX }}
+          path: ${{ env.SUFFIX }}
+          if-no-files-found: error
+          retention-days: 7
+
+  # based on https://allenhwkim.medium.com/semantic-release-without-npm-2af48cdf3098
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    environment: release
+    needs: [linux]
+    steps:
+      - name: Mock package.json
+        # because I hate that 20-or-so dot-files peppering the base directory
+        # of a project -- can't find the source files in all the forest of
+        # vanity config files
+        #
+        # Epic jq: jq -S '.release.plugins[2][1].assets |= ["bob"]' package.json
+        #  echo '{ "name": "kernel-mods", "private": true, "release": { "branches": ["master"], "plugins": [ "@semantic-release/commit-analyzer", "@semantic-release/release-notes-generator", [ "@semantic-release/github", { "assets": [ { "path": "build-denverton", "label": "Denverton" }, { "path": "build-geminilake", "label": "GeminiLake" } ] } ] ] } }' > package.json
+        run: |
+          echo '{ "name": "kernel-mods", "private": true, "release": { "branches": ["master"], "plugins": [ "@semantic-release/commit-analyzer", "@semantic-release/release-notes-generator", [ "@semantic-release/github", { "assets": [ "build-*" ] } ] ] } }' > package.json
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          # It is recommended to specify a version range for semantic-release
+          # when using semantic-release-action lower than @v4
+          semantic_version: 19.0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+package.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# To install the dependencies for this file:
+# 1) pip install pre-commit
+#   (really, "sudo python3 -m pip install pre-commit")
+#   (really, I've been carrying this boilerplate for years, but now it's all python3?)
+#
+# 2) pre-commit install --allow-missing-config
+#
+# yamllint checks this .pre-commit-config file as well
+---
+repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: [
+          '-d',
+          '{extends: default, rules: {line-length: {max: 400}}}'
+        ]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.0
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # example-semantic-release
+
 Example / Experimentation in Semantic-Release rpm tool
+
+(https://semantic-release.gitbook.io/semantic-release)


### PR DESCRIPTION
This is the initial stack of Semantic-Release configs, based on merging:
 - https://allenhwkim.medium.com/semantic-release-without-npm-2af48cdf3098 (don't use)
 - https://docs.renovatebot.com/semantic-commits/
 - https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format
 - https://github.com/cycjimmy/semantic-release-action?tab=readme-ov-file
 - https://github.com/marketplace/actions/action-for-semantic-release
 - https://github.com/semantic-release/github/releases
 - https://github.com/semantic-release/github?tab=readme-ov-file
 - https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration
 - https://github.com/semantic-release/semantic-release/blob/master/docs/usage/plugins.md#plugins
 - https://github.com/semantic-release/semantic-release?tab=readme-ov-file
 - https://github.com/webiny/action-conventional-commits
 - https://semantic-release.gitbook.io/semantic-release/usage/plugins#default-plugins

I did not yet choose:
 - https://github.com/google-github-actions/release-please-action